### PR TITLE
Support multiple audiences in API

### DIFF
--- a/src/routes/[project=valid_project]/[book=valid_book]/[chapter=integer]/[verse=integer]/+server.js
+++ b/src/routes/[project=valid_project]/[book=valid_book]/[chapter=integer]/[verse=integer]/+server.js
@@ -1,22 +1,18 @@
 // https://kit.svelte.dev/docs/routing#server
-import { error, json } from '@sveltejs/kit'
+import { json } from '@sveltejs/kit'
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ locals: { db }, params: { project, book, chapter, verse } }) {
 	const sql = `
-		SELECT DISTINCT text
+		SELECT DISTINCT text, audience
 		FROM Text
 		WHERE project = ?
 			AND book = ?
 			AND chapter = ?
 			AND verse = ?
 	`
-	/** @type {TextResult|null} https://developers.cloudflare.com/d1/platform/client-api/#return-object */
-	const result = await db.prepare(sql).bind(project, book, chapter, verse).first()
+	/** @type {import('@cloudflare/workers-types').D1Result<TextResult>} https://developers.cloudflare.com/d1/platform/client-api/#return-object */
+	const { results } = await db.prepare(sql).bind(project, book, chapter, verse).all()
 
-	if (!result) {
-		return error(404, 'Not found')
-	}
-
-	return json(result.text)
+	return json(results)
 }

--- a/src/routes/[project=valid_project]/[book=valid_book]/[chapter=integer]/[verse=integer]/index.d.ts
+++ b/src/routes/[project=valid_project]/[book=valid_book]/[chapter=integer]/[verse=integer]/index.d.ts
@@ -1,3 +1,4 @@
 type TextResult = {
-	text: number
+	text: string
+	audience: string
 }


### PR DESCRIPTION
Include the audience as part of the API return object, and return an array of results instead of just one.