### PR TITLE
Add return_to query parameter

### DIFF
--- a/src/lib/Search.svelte
+++ b/src/lib/Search.svelte
@@ -7,6 +7,9 @@
 	
 	/** @type {string|null} */
 	let value = new URLSearchParams(page.url.search).get('q')
+
+	/** @type {string|null} */
+	let return_to = new URLSearchParams(page.url.search).get('return_to')
 </script>
 
 <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search -->
@@ -21,5 +24,9 @@
 			<span class="hidden sm:inline">Search</span>
 			<Icon icon="material-symbols:search" class="h-6 w-6" />
 		</button>
+
+		{#if return_to}
+			<input type="hidden" name="return_to" id="return_to" bind:value={return_to} />
+		{/if}
 	</form>
 </search>

--- a/src/routes/[project=valid_project]/search/+layout.svelte
+++ b/src/routes/[project=valid_project]/search/+layout.svelte
@@ -14,6 +14,6 @@
 	<Search {project} />
 </header>
 
-<main class="mx-8 mt-8">
+<main class="mx-8 mt-6">
 	{@render children?.()}
 </main>

--- a/src/routes/[project=valid_project]/search/+page.server.js
+++ b/src/routes/[project=valid_project]/search/+page.server.js
@@ -7,9 +7,14 @@ export async function load({ url: { searchParams }, params: { project }, locals:
 		return { results: [], search_term: '' }
 	}
 
+	const return_to_raw = searchParams.get('return_to')?.trim()
+	/** @type {ReturnTo|undefined} */
+	const return_to = return_to_raw ? JSON.parse(decodeURIComponent(return_to_raw)) : undefined
+
 	const results = await search_text(db, project, q)
 	return {
 		results,
 		search_term: q,
+		return_to,
 	}
 }

--- a/src/routes/[project=valid_project]/search/+page.svelte
+++ b/src/routes/[project=valid_project]/search/+page.svelte
@@ -3,9 +3,13 @@
 	import Icon from '@iconify/svelte'
 	import { SourceData } from '$lib'
 	import { bible_books } from '$lib/lookups'
+	import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
 
 	/** @type {import('./$types').PageData} */
 	export let data
+
+	/** @type {ReturnTo|undefined}*/
+	const return_to = data.return_to
 
 	$: matches = data.results
 	$: found = !!matches.length
@@ -102,6 +106,16 @@
 		return index_1 - index_2
 	}
 </script>
+
+<!--Eventually return_to may support other values as well-->
+{#if return_to?.app === 'ontology'}
+	<div class="mb-2">
+		<a class="btn" href="{PUBLIC_ONTOLOGY_API_HOST}{return_to.q ? `?q=${return_to.q}` : '/'}">
+			<Icon icon="mdi:arrow-left-thin" class="h-6 w-6" />
+			Return to Ontology
+		</a>
+	</div>
+{/if}
 
 <header class="flex justify-between">
 	<em class="badge badge-lg invisible gap-2" class:visible={searched} class:badge-success={found} class:badge-warning={!found}>

--- a/src/routes/[project=valid_project]/search/index.d.ts
+++ b/src/routes/[project=valid_project]/search/index.d.ts
@@ -13,3 +13,8 @@ type SearchTextResult = {
 }
 
 type FilterMap = Map<string, string[]>
+
+type ReturnTo = {
+	app: string
+	q: string
+}


### PR DESCRIPTION
Added query parameter to tell the app where it came from (if anywhere). This is so that a user that came here from the Ontology can return to where they left off.

Using the Ontology URL that redirected here doesn't work, because in that URL is the value that tells the Ontology to redirect in the first place. So I created a ReturnTo object that contains the app name and search query. I don't think there's any way (unless we start tracking it) what the ontology search was _before_ the query that lead to the Targets search.

## With `return_to`
<img width="1423" height="509" alt="image" src="https://github.com/user-attachments/assets/8868f921-4961-464f-9e46-82297bdbda9b" />

The orignal `return_to.q` is preserved even when the user changes their search.

## No change when there is no `return_to`
<img width="1429" height="416" alt="image" src="https://github.com/user-attachments/assets/cbd0c515-4989-4e00-ae64-2e82c8d4a143" />
